### PR TITLE
chore: add support for hostname prometheus tag and global tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "clap",
  "dotenv",
  "futures",
+ "hostname",
  "http",
  "metrics",
  "metrics-derive",
@@ -738,6 +739,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows",
 ]
 
 [[package]]
@@ -2452,6 +2464,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ metrics = "0.24.1"
 metrics-derive = "0.1"
 thiserror = "2.0.11"
 serde_json = "1.0.138"
+hostname = "0.4.0"
 
 [features]
 integration = []


### PR DESCRIPTION
### Description
Add ability to add automatic hostname tags to prometheus metrics and a generic global tag function.

Example output:
```
# HELP websocket_proxy_upstream_messages Count of messages received from the upstream source
# TYPE websocket_proxy_upstream_messages gauge
websocket_proxy_upstream_messages{hostname="N9WT6WH12Y",hello="world",blah="bah"} 2
```